### PR TITLE
OTS-1214 Update Accelerator Sample Apps for Core 2.0

### DIFF
--- a/react-sample-app/package.json
+++ b/react-sample-app/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "opentok-accelerator-core": "*",
+    "opentok-accelerator-core": ">=2.0.0",
     "opentok-annotation": "*",
     "opentok-archiving": "*",
     "opentok-screen-sharing": "*",

--- a/react-sample-app/src/App.js
+++ b/react-sample-app/src/App.js
@@ -3,14 +3,14 @@ import React, { Component } from 'react';
 import Spinner from 'react-spinner';
 import classNames from 'classnames';
 
-import otCore from 'opentok-accelerator-core';
+import AccCore from 'opentok-accelerator-core';
 import 'opentok-solutions-css';
 
 import logo from './logo.svg';
 import config from './config.json';
 import './App.css';
 
-
+let otCore;
 const otCoreOptions = {
   credentials: {
     apiKey: config.apiKey,
@@ -18,7 +18,7 @@ const otCoreOptions = {
     token: config.token,
   },
   // A container can either be a query selector or an HTML Element
-  streamContainers(pubSub, type, data, streamId) {
+  streamContainers(pubSub, type, data, stream) {
     return {
       publisher: {
         camera: '#cameraPublisherContainer',
@@ -124,7 +124,7 @@ class App extends Component {
   }
 
   componentDidMount() {
-    otCore.init(otCoreOptions);
+    otCore = new AccCore(otCoreOptions);
     otCore.connect().then(() => this.setState({ connected: true }));
     const events = [
       'subscribeToCamera',
@@ -142,13 +142,13 @@ class App extends Component {
 
   startCall() {
     otCore.startCall()
-      .then(({ publisher, publishers, subscribers, meta }) => {
+      .then(({ publishers, subscribers, meta }) => {
         this.setState({ publishers, subscribers, meta, active: true });
       }).catch(error => console.log(error));
   }
 
   endCall() {
-    otCore.endCall()
+    otCore.endCall();
     this.setState({ active: false });
   }
 

--- a/vanilla-js-sample-app/package.json
+++ b/vanilla-js-sample-app/package.json
@@ -8,7 +8,7 @@
     "start": "node server.js",
     "cp-annotation": "cp node_modules/opentok-annotation/dist/opentok-annotation.js public/js/components/",
     "cp-archiving": "cp node_modules/opentok-archiving/dist/opentok-archiving.js public/js/components/",
-    "cp-screen-sharing":"cp node_modules/opentok-screen-sharing/dist/opentok-screen-sharing.js public/js/components/",
+    "cp-screen-sharing": "cp node_modules/opentok-screen-sharing/dist/opentok-screen-sharing.js public/js/components/",
     "cp-text-chat": "cp node_modules/opentok-text-chat/dist/opentok-text-chat.js public/js/components/",
     "cp-logging": "cp node_modules/opentok-solutions-logging/dist/opentok-solutions-logging.js public/js/components/",
     "cp-core": "cp node_modules/opentok-accelerator-core/browser/opentok-acc-core.js public/js/components/",
@@ -25,5 +25,12 @@
     "opentok-screen-sharing": "*",
     "opentok-solutions-css": "*",
     "opentok-text-chat": "*"
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.3"
   }
 }

--- a/vanilla-js-sample-app/package.json
+++ b/vanilla-js-sample-app/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "body-parser": "^1.16.0",
     "express": "^4.14.1",
-    "opentok-accelerator-core": "*",
+    "opentok-accelerator-core": ">=2.0.0",
     "opentok-annotation": "*",
     "opentok-archiving": "*",
     "opentok-screen-sharing": "*",

--- a/vanilla-js-sample-app/public/js/app.js
+++ b/vanilla-js-sample-app/public/js/app.js
@@ -1,5 +1,6 @@
-/* global otCore */
+/* global AccCore */
 
+let otCore;
 const options = {
   // A container can either be a query selector or an HTMLElement
   streamContainers: function streamContainers(pubSub, type, data) {
@@ -175,7 +176,7 @@ const app = () => {
    * Initialize otCore, connect to the session, and listen to events
    */
   const init = () => {
-    otCore.init(options);
+    otCore = new AccCore(options);
     otCore.connect().then(() => updateState({ connected: true }));
     createEventListeners();
   };


### PR DESCRIPTION
Apps Updated:

- React Sample app for core

- Vanilla Sample app for core

Things Updated:

- `package.json` to require `opentok-accelerator-core>=2.0.0`

- Use `global AccCore`, `let otCore` and `new AccCore` instead of `global `otCore` and `otCore.init`
