### PR TITLE
update screen-sharing version for compatability with opentok.js 2.13

### DIFF
--- a/react-sample-app/package.json
+++ b/react-sample-app/package.json
@@ -15,7 +15,7 @@
     "opentok-accelerator-core": ">=2.0.0",
     "opentok-annotation": "*",
     "opentok-archiving": "*",
-    "opentok-screen-sharing": "*",
+    "opentok-screen-sharing": ">=1.0.28",
     "opentok-solutions-css": "*",
     "opentok-text-chat": "*",
     "react": "^15.3.2",

--- a/vanilla-js-sample-app/package.json
+++ b/vanilla-js-sample-app/package.json
@@ -22,7 +22,7 @@
     "opentok-accelerator-core": ">=2.0.0",
     "opentok-annotation": "*",
     "opentok-archiving": "*",
-    "opentok-screen-sharing": "*",
+    "opentok-screen-sharing": ">=1.0.28",
     "opentok-solutions-css": "*",
     "opentok-text-chat": "*"
   },


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.

#### This fixes issue #18 .

## What's in this pull request?

> Update opentok-screen-sharing version to 1.0.28 for compatability with opentok.js 2.13