### PR TITLE
updated deprecated method 

### DIFF
--- a/vanilla-js-sample-app/server.js
+++ b/vanilla-js-sample-app/server.js
@@ -25,5 +25,6 @@ app.get('/', (req, res) => {
 /*
  * Listen
  */
-app.listen(process.env.PORT || port);
-console.log(`app listening on port ${port}`);
+app.listen(process.env.PORT || port, () => {
+  console.log(`app listening on port ${port}`);
+});

--- a/vanilla-js-sample-app/server.js
+++ b/vanilla-js-sample-app/server.js
@@ -19,7 +19,7 @@ app.use(bodyParser.json());
  */
 
 app.get('/', (req, res) => {
-  res.sendfile('public/index.html');
+  res.sendFile('public/index.html');
 });
 
 /*


### PR DESCRIPTION

#### This fixes issue #___.
app listening on port will printed after its start listening 

## What's in this pull request?
changed res.sendfile to res.sendFile as its deprecated 
